### PR TITLE
Add port listing

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -8,7 +8,7 @@ import type { DeviceManagerExtension } from '@arm-debug/vcsode-device-manager';
 const deviceManagerExtension = vscode.extensions.getExtension<DeviceManagerExtension>('Arm.device-manager');
 if (deviceManagerExtension) {
     const deviceManager = await extension.activate();
-    const deviceManagerV1 = deviceManager.getApi(1);
-    const devices = await deviceManagerV1.getDevices();
+    const deviceManagerV2 = deviceManager.getApi(2);
+    const devices = await deviceManagerV2.getDevices();
 }
 ```

--- a/api/package.json
+++ b/api/package.json
@@ -8,6 +8,6 @@
     },
     "repository": "https://github.com/eclipse-cdt-cloud/vscode-serial-monitor",
     "dependencies": {
-        "@types/w3c-web-serial": "^1.0.6"
+        "@types/w3c-web-serial": "^1.0.8"
     }
 }

--- a/api/serial-monitor.d.ts
+++ b/api/serial-monitor.d.ts
@@ -15,6 +15,15 @@ export interface SerialFilter {
     path?: string;
 }
 
+// The web version can ony populate vid/pid
+export interface SerialInfo {
+    path?: string;
+    serialNumber?: string;
+    manufacturer?: string;
+    productId?: string;
+    vendorId?: string;
+}
+
 export interface SerialMonitorApiV1 {
     openSerial(portOrFilter?: SerialPort | SerialFilter, options?: SerialOptions, name?: string): Promise<string | undefined>;
     revealSerial(handle: string): Promise<boolean>;
@@ -22,6 +31,11 @@ export interface SerialMonitorApiV1 {
     resumeSerial(handle: string): Promise<boolean>;
 }
 
+export interface SerialMonitorApiV2 extends SerialMonitorApiV1 {
+    listPorts(): Promise<SerialInfo[]>;
+}
+
 export interface SerialMonitorExtension {
     getApi(version: 1): SerialMonitorApiV1;
+    getApi(version: 2): SerialMonitorApiV2;
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.10.7",
     "@types/vscode": "^1.63.0",
-    "@types/w3c-web-serial": "^1.0.7",
+    "@types/w3c-web-serial": "^1.0.8",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@vscode/vsce": "^3.2.1",

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
 
-import { SerialMonitorApiV1, SerialMonitorExtension } from '../api/serial-monitor';
+import { SerialMonitorApiV1, SerialMonitorApiV2, SerialMonitorExtension } from '../api/serial-monitor';
 import { SerialManager } from './serial-manager';
 
 export class SerialMonitorImpl implements SerialMonitorExtension {
@@ -17,8 +17,9 @@ export class SerialMonitorImpl implements SerialMonitorExtension {
     ) {}
 
     public getApi(version: 1): SerialMonitorApiV1;
+    public getApi(version: 2): SerialMonitorApiV2;
     public getApi(version: number): unknown {
-        if (version === 1) {
+        if (version === 1 || version === 2) {
             return this.serialManager;
         }
 

--- a/src/browser/browser-device-provider.ts
+++ b/src/browser/browser-device-provider.ts
@@ -11,11 +11,20 @@
 import * as vscode from 'vscode';
 import { SerialDeviceProvider } from '../serial-manager';
 import { SerialDevice, SerialPortDevice } from '../serial-device';
-import { SerialFilter } from '../../api/serial-monitor';
+import { SerialFilter, SerialInfo } from '../../api/serial-monitor';
 
 const WEBSERIAL_COMMAND = 'workbench.experimental.requestSerialPort';
 
 export class BrowserDeviceProvider implements SerialDeviceProvider {
+
+    public async listPorts(): Promise<SerialInfo[]> {
+        const ports = await navigator.serial.getPorts();
+        const portInfos = await Promise.all(ports.map(port => port.getInfo()));
+        return portInfos.map(port => ({
+            productId: port.usbProductId?.toString(),
+            vendorId: port.usbVendorId?.toString()
+        }));
+    }
 
     public async getDevice(filter?: SerialFilter): Promise<SerialDevice | undefined> {
         let port: SerialPort | undefined;

--- a/src/desktop/desktop-device-provider.ts
+++ b/src/desktop/desktop-device-provider.ts
@@ -13,7 +13,7 @@ import { SerialPort } from 'serialport';
 import { PortInfo } from '@serialport/bindings-cpp';
 import { DesktopSerialDevice, getName } from './desktop-serial-device';
 import { SerialDeviceProvider } from '../serial-manager';
-import { SerialFilter } from '../../api/serial-monitor';
+import { SerialFilter, SerialInfo } from '../../api/serial-monitor';
 import { SerialDevice } from '../serial-device';
 
 class PortItem implements vscode.QuickPickItem {
@@ -24,6 +24,17 @@ class PortItem implements vscode.QuickPickItem {
 }
 
 export class DesktopDeviceProvider implements SerialDeviceProvider {
+
+    public async listPorts(): Promise<SerialInfo[]> {
+        const ports = await SerialPort.list();
+        return ports.map(port => ({
+            path: port.path,
+            serialNumber: port.serialNumber,
+            manufacturer: port.manufacturer,
+            productId: port.productId,
+            vendorId: port.vendorId
+        }));
+    }
 
     public async getDevice(filter?: SerialFilter): Promise<SerialDevice | undefined> {
         let port = await this.getPortInfo(filter);

--- a/src/serial-manager.ts
+++ b/src/serial-manager.ts
@@ -12,9 +12,10 @@ import * as vscode from 'vscode';
 import * as manifest from './manifest';
 import { SerialTerminal } from './serial-terminal';
 import { SerialDevice, SerialPortDevice } from './serial-device';
-import { SerialFilter, SerialMonitorApiV1 } from '../api/serial-monitor';
+import { SerialFilter, SerialInfo, SerialMonitorApiV1 } from '../api/serial-monitor';
 
 export interface SerialDeviceProvider {
+    listPorts(): Promise<SerialInfo[]>;
     getDevice: (filter?: SerialFilter) => Promise<SerialDevice | undefined>;
 }
 
@@ -45,6 +46,10 @@ export class SerialManager implements SerialMonitorApiV1 {
         );
 
         this.updateStatus();
+    }
+
+    public async listPorts(): Promise<SerialInfo[]> {
+        return this.serialDeviceProvider.listPorts();
     }
 
     public async openSerial(portOrFilter?: SerialPort | SerialFilter, options?: SerialOptions, name?: string): Promise<string | undefined> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -421,10 +421,10 @@
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.78.0.tgz#b5600abce8855cf21fb32d0857bcd084b1f83069"
   integrity sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==
 
-"@types/w3c-web-serial@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@types/w3c-web-serial/-/w3c-web-serial-1.0.7.tgz#44416509af271e5196833ff5e1337c7c256991c6"
-  integrity sha512-jzcwm//EZ0Z306L1/O1GXC3GthRd//9eaNB4/Yagm98UjEQViTzDS8bYvL+y+rTk1r9OFt9Yhp5pprUQFzSiiQ==
+"@types/w3c-web-serial@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@types/w3c-web-serial/-/w3c-web-serial-1.0.8.tgz#38338a26b45ffbcc85596c3940bcafeb90200529"
+  integrity sha512-QQOT+bxQJhRGXoZDZGLs3ksLud1dMNnMiSQtBA0w8KXvLpXX4oM4TZb6J0GgJ8UbCaHo5s9/4VQT8uXy9JER2A==
 
 "@typescript-eslint/eslint-plugin@^5.62.0":
   version "5.62.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-serial-monitor/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add port listing functionality to the API. This allows another extension to list ports this extension can see in order to select one to show. Removes the need for another extension to add functionality to list ports (e.g. another dependency on the SerialPort module).
Upped the API to v2 as it has been modified.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Use the example in the api readme file to programatically control the serial port functionality. try listing ports with `.listPorts()`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
